### PR TITLE
EffectSelector: Remember selected tab, default to setEffectList default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1964,7 +1964,7 @@ function handleEffectSlotSelectEffect(zoomPatch: ZoomPatch | undefined, zoomDevi
   {
     shouldLog(LogLevel.Info) && console.log(`Selecting effect in slot ${effectSlot}`);
 
-    zoomEffectSelector!.getEffect(zoomPatch.effectSettings[effectSlot].id, zoomDevice ? zoomDevice.deviceName : "MS-70CDR").then(([effectID, effectName, pedalName]) => {
+    zoomEffectSelector!.getEffect(zoomPatch.effectSettings[effectSlot].id).then(([effectID, effectName, pedalName]) => {
       console.log(`User selected effectID: ${effectID}, effectName: ${effectName}, pedalName: ${pedalName}`);
 
       if (effectID !== -1) {


### PR DESCRIPTION
The Effect Selector dialog currently opens to the tab of your pedal every time. This change makes it first open to the default you set when setting the effectsList (`zoomEffectSelector.setEffectsList(effectLists, whateverDefaultTabUsuallyDeviceName)`). If you change the tab, the selector will remember that and reopen to the last-used tab next time you open it. 

This synergizes well with my other PR, which makes the setEffectsList default the Installed tab.